### PR TITLE
Omstrukturering och ny klass för dbuppkoppling

### DIFF
--- a/SDG Admin/src/Database/DatabaseInterface.java
+++ b/SDG Admin/src/Database/DatabaseInterface.java
@@ -1,0 +1,34 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package Database;
+import oru.inf.InfDB;
+import oru.inf.InfException;
+/**
+ * This file includes a static method which establishes a connection to the database through the InfDB class. This class exists to ease
+ * communication with the database.
+ * @author theow
+ */
+public class DatabaseInterface {
+    
+    private static InfDB idb;
+
+    
+    public DatabaseInterface() {
+    
+    
+}
+    
+    public static InfDB databaseConnection() {
+        // TODO code application logic here
+        try {
+            idb = new InfDB("sdgsweden", "3306", "dbAdmin2024", "dbAdmin2024PW");
+        } catch (InfException ex){
+            System.out.println(ex.getMessage());
+        }
+        
+        return idb;
+    }
+    
+}

--- a/SDG Admin/src/GUI/inloggning.java
+++ b/SDG Admin/src/GUI/inloggning.java
@@ -7,6 +7,7 @@ package GUI;
 
 import oru.inf.InfDB;
 import oru.inf.InfException;
+import Database.DatabaseInterface;
 
 /**
  *
@@ -17,8 +18,9 @@ public class inloggning extends javax.swing.JFrame {
     private InfDB idb;
 
     /** Creates new form inloggning */
-    public inloggning(InfDB idb) {
-        this.idb = idb;
+    public inloggning() {
+        
+        idb = DatabaseInterface.databaseConnection();
         initComponents();
         felUppgifter.setVisible(false);
     }

--- a/SDG Admin/src/OrgEntities/Admin.java
+++ b/SDG Admin/src/OrgEntities/Admin.java
@@ -1,0 +1,13 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package OrgEntities;
+
+/**
+ *
+ * @author theow
+ */
+public class Admin {
+    
+}

--- a/SDG Admin/src/OrgEntities/Anstalld.java
+++ b/SDG Admin/src/OrgEntities/Anstalld.java
@@ -1,0 +1,31 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package OrgEntities;
+import java.util.HashMap;
+import oru.inf.InfDB;
+import oru.inf.InfException;
+/**
+ *
+ * @author theow
+ */
+
+
+
+/* public class Anstalld {
+    
+    private HashMap<String, String> anstalld; 
+    private InfDB idb;
+    private String query;
+    
+    public Anstalld(InfDB idb) {
+    
+    this.idb = idb;
+    anstalld = idb.fetchRow(query)
+        
+        
+    }
+    
+    
+}*/

--- a/SDG Admin/src/OrgEntities/Avdelning.java
+++ b/SDG Admin/src/OrgEntities/Avdelning.java
@@ -1,0 +1,13 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package OrgEntities;
+
+/**
+ *
+ * @author theow
+ */
+public class Avdelning {
+    
+}

--- a/SDG Admin/src/OrgEntities/Hallbarhetsmål.java
+++ b/SDG Admin/src/OrgEntities/Hallbarhetsmål.java
@@ -1,0 +1,13 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package OrgEntities;
+
+/**
+ *
+ * @author theow
+ */
+public class Hallbarhetsmål {
+    
+}

--- a/SDG Admin/src/OrgEntities/Handlaggare.java
+++ b/SDG Admin/src/OrgEntities/Handlaggare.java
@@ -1,0 +1,13 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package OrgEntities;
+
+/**
+ *
+ * @author theow
+ */
+public class Handlaggare {
+    
+}

--- a/SDG Admin/src/OrgEntities/Land.java
+++ b/SDG Admin/src/OrgEntities/Land.java
@@ -1,0 +1,13 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package OrgEntities;
+
+/**
+ *
+ * @author theow
+ */
+public class Land {
+    
+}

--- a/SDG Admin/src/OrgEntities/Partner.java
+++ b/SDG Admin/src/OrgEntities/Partner.java
@@ -1,0 +1,13 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package OrgEntities;
+
+/**
+ *
+ * @author theow
+ */
+public class Partner {
+    
+}

--- a/SDG Admin/src/OrgEntities/Projekt.java
+++ b/SDG Admin/src/OrgEntities/Projekt.java
@@ -1,0 +1,13 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package OrgEntities;
+
+/**
+ *
+ * @author theow
+ */
+public class Projekt {
+    
+}

--- a/SDG Admin/src/OrgEntities/Stad.java
+++ b/SDG Admin/src/OrgEntities/Stad.java
@@ -1,0 +1,13 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package OrgEntities;
+
+/**
+ *
+ * @author theow
+ */
+public class Stad {
+    
+}

--- a/SDG Admin/src/sdg/admin/SDGAdmin.java
+++ b/SDG Admin/src/sdg/admin/SDGAdmin.java
@@ -4,8 +4,9 @@
  */
 package sdg.admin;
 import GUI.inloggning;
-import oru.inf.InfDB;
+import Database.DatabaseInterface;
 import oru.inf.InfException;
+
 
 /**
  *
@@ -13,18 +14,14 @@ import oru.inf.InfException;
  * Denna fil innehåller programmets initiala mainmetod.
  */
 public class SDGAdmin {
-    private static InfDB idb;
     /**
      * @param args the command line arguments
      */
     public static void main(String[] args) {
         // TODO code application logic here
-        try {
-            idb = new InfDB("sdgsweden", "3306", "dbAdmin2024", "dbAdmin2024PW");
-            new inloggning(idb).setVisible(true);
-        } catch (InfException ex){
-            System.out.println(ex.getMessage());
-        }
-    }
+        
+            new inloggning().setVisible(true);
+        
     
+    }
 }


### PR DESCRIPTION
Jag har skapat en javaklass som har en klassmetod som när den kallas returnerar ett InfDB objekt som innehåller uppkopplingsuppgifter till databasen. Så om man behöver prata med databasen i sin fil, kan man skapa en variabel av typen InfDB som ett fält och i konstruktorn ge den värdet av metoden databaseConnection, alltså ex:  InfDB idb = DatabaseInterface.databaseConnection() Glöm inte att du måste även importera oru.inf.InfDB för att kunna skapa en variabel av objekttypen InfDB :)

Vidare lades nya klasser till för verksamhetens entiteter. Om vi går vidare med att använda dem var väl tanken att varje klass ska innehålla en hashmap med all information från databasen, där ett individuellt objekt då är exempelvis en enda anställd, ett projekt eller en partner. 